### PR TITLE
Upgrade to support RN 0.69.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,19 +1,20 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath("com.android.tools.build:gradle:7.1.1")
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 31
+    buildToolsVersion "31.0.0"
 
     externalNativeBuild {
         cmake {
@@ -23,8 +24,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }
@@ -38,5 +39,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,2 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+


### PR DESCRIPTION
Upgrade android's build.gradle to support RN 0.69.4 . Specifically convert `compile` -> `implementation`. Also bumped minsdk versions and gradle version to match our main repo.