### PR TITLE
pass through mode option for vad

### DIFF
--- a/android/src/main/cpp/VoiceActivityDetector.cpp
+++ b/android/src/main/cpp/VoiceActivityDetector.cpp
@@ -1,10 +1,10 @@
 #include "VoiceActivityDetector.h"
 #include "webrtc_vad.h"
 
-VoiceActivityDetector::VoiceActivityDetector(){
+VoiceActivityDetector::VoiceActivityDetector(int mode){
     WebRtcVad_Create(&this->vad);
     WebRtcVad_Init(this->vad);
-    WebRtcVad_set_mode(this->vad, 0);
+    WebRtcVad_set_mode(this->vad, mode);
 }
 
 VoiceActivityDetector::~VoiceActivityDetector(){

--- a/android/src/main/cpp/VoiceActivityDetector.extern.cpp
+++ b/android/src/main/cpp/VoiceActivityDetector.extern.cpp
@@ -7,8 +7,8 @@ extern "C" {
 
 VoiceActivityDetector *vad = nullptr;
 
-void initialize() {
-    vad = new VoiceActivityDetector();
+void initialize(jint mode) {
+    vad = new VoiceActivityDetector(mode);
 }
 
 void stop() {
@@ -22,8 +22,9 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_guilded_gg_RNWebrtcVadModule_initializeVad(
         JNIEnv
         *env,
-        jobject /* this */) {
-    initialize();
+        jobject /* this */,
+        jint mode) {
+    initialize(mode);
 
 }
 

--- a/android/src/main/cpp/VoiceActivityDetector.h
+++ b/android/src/main/cpp/VoiceActivityDetector.h
@@ -16,7 +16,7 @@ private:
 public:
     bool isVoice(const int16_t* audio_frame, int sample_rate, int frame_length);
 
-    VoiceActivityDetector();
+    VoiceActivityDetector(int mode);
 
     ~VoiceActivityDetector();
 

--- a/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
+++ b/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
@@ -35,7 +35,7 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
         SoLoader.loadLibrary("voice-activity-detector");
     }
 
-    private static native void initializeVad();
+    private static native void initializeVad(int mode);
 
     private static native void stopVad();
 
@@ -50,8 +50,9 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
     @ReactMethod
     public void start(ReadableMap options) {
         Log.d(getName(), "Starting");
+        int mode = options != null && options.hasKey("mode") ? options.getInt("mode") : 0;
 
-        RNWebrtcVadModule.initializeVad();
+        RNWebrtcVadModule.initializeVad(mode);
         final AudioInputController inputController = AudioInputController.getInstance();
 
         // If not specified, will match HW sample, which could be too high.

--- a/ios/RNWebrtcVad.m
+++ b/ios/RNWebrtcVad.m
@@ -15,8 +15,8 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(start:(NSDictionary *)options)
 {
     NSLog(@"[WebRTCVad] starting = %@", options);
-    voiceDetector = [[VoiceActivityDetector alloc] init];
-
+    int mode = [options[@"mode"] intValue];
+    voiceDetector = [[VoiceActivityDetector alloc] initWithMode:mode];
     AudioInputController *inputController = [AudioInputController sharedInstance];
 
     // If not specified, will match HW sample, which could be too high.

--- a/ios/VoiceActivityDetector.h
+++ b/ios/VoiceActivityDetector.h
@@ -5,7 +5,12 @@ typedef struct WebRtcVadInst VadInst;
 
 #import <Foundation/Foundation.h>
 
+extern const int DEFAULT_VAD_MODE;
+
 @interface VoiceActivityDetector : NSObject
+
+-(instancetype)initWithMode: (int)mode;
+-(instancetype)init;
 
 -(int)isVoice:(const int16_t*)audio_frame sample_rate:(int)fs length:(int) frame_length;
 @end

--- a/ios/VoiceActivityDetector.m
+++ b/ios/VoiceActivityDetector.m
@@ -1,19 +1,24 @@
 #include "webrtc/common_audio/vad/include/webrtc_vad.h"
 #import "VoiceActivityDetector.h"
 
+const int DEFAULT_VAD_MODE = 0;
+
 @implementation VoiceActivityDetector {
     VadInst *vad;
 }
 
-- (instancetype)init {
-
+- (instancetype)initWithMode: (int)mode {
     self = [super init];
     if(self) {
         WebRtcVad_Create(&vad);
         WebRtcVad_Init(vad);
-        WebRtcVad_set_mode(vad, 0);
+        WebRtcVad_set_mode(vad, mode);
     }
     return self;
+}
+
+- (instancetype)init {
+    return [self initWithMode:DEFAULT_VAD_MODE];
 }
 
 - (void)dealloc {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc-vad",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This allows us to set "mode" for the voice activity detector from the JS side. In testing, Android did seem to stop responding to voice events at 3, and barely at 2. This might not get us what we want, but being able to test out different values on the JS side will be helpful.