### PR TITLE
Gary/fix ios bluetooth part 2

### DIFF
--- a/ios/AudioInputController.m
+++ b/ios/AudioInputController.m
@@ -88,8 +88,8 @@
         // speaker output wouldn't work until I switched to bluetooth and back.
         // 0.063 seconds yields 3024 samples at 48khz. 2778 at 44.1khz.
         // 1 ms higher at 0.064 caused iPhone 14/15 Pro speakers to stop
-        // working properly with choppy audio. 0.02 caused mic input in our app
-        // to stop working (tested on iPhone 12 Pro and iPhone 15 Pro).
+        // working properly with choppy audio. 0.02 caused mic input and speaker
+        // output in our app to stop working (tested on iPhone 12/15 Pro).
         [audioSession setPreferredIOBufferDuration:0.063 error:nil];
 
     } @catch (NSException *e) {

--- a/ios/AudioInputController.m
+++ b/ios/AudioInputController.m
@@ -83,11 +83,14 @@
 
         NSLog(@"[WebRTCVad] set mode %d", ok);
 
-        // 0.064 was arrived at via trial and error. Too large of a buffer and
+        // 0.063 was arrived at via trial and error. Too large of a buffer and
         // my bluetooth earbuds would start beeping relentlessly. Too small and
         // speaker output wouldn't work until I switched to bluetooth and back.
-        // 0.064 seconds yields 3072 samples at 48khz. 2822 at 44.1khz.
-        [audioSession setPreferredIOBufferDuration:0.064 error:nil];
+        // 0.063 seconds yields 3024 samples at 48khz. 2778 at 44.1khz.
+        // 1 ms higher at 0.064 caused iPhone 14/15 Pro speakers to stop
+        // working properly with choppy audio. 0.02 caused mic input in our app
+        // to stop working (tested on iPhone 12 Pro and iPhone 15 Pro).
+        [audioSession setPreferredIOBufferDuration:0.063 error:nil];
 
     } @catch (NSException *e) {
         NSLog(@"[WebRTCVad]: session setup failed: %@", e.reason);

--- a/ios/RNWebrtcVad.m
+++ b/ios/RNWebrtcVad.m
@@ -69,7 +69,7 @@ RCT_EXPORT_METHOD(stop) {
 
     const double sampleLengthMs = 0.02;
 
-    cumulativeProcessedSampleLengthMs += sampleLengthMs;
+    cumulativeProcessedSampleLengthMs += [data length] / sampleRate;
     int chunkSizeBytes = sampleLengthMs /* seconds/chunk */ * sampleRate * 2 /* bytes/sample */ ; /* bytes/chunk */
 
     if ([self.audioData length] >= chunkSizeBytes) {


### PR DESCRIPTION
Jocelyn reported that on her iPhone 14 Pro, voices came through incredible choppy. See [task](https://www.tarobi-dev-test.com/guilded-dev/groups/l3GMMObd/channels/4945e21c-851b-4001-9899-0985ec2dae48/list?listItemId=073eaab6-db7f-4334-9e37-a9e924acbee3) for example. I was able to reproduce this on iPhone 15 Pro, but not on the iPhone 12 Pro which is what I had tested the last fix on.

I don't think you guys are going to like this follow-up. I don't understand why it works or if it'll break in the future or even if it works on all iPhones out now. I couldn't find much documentation here, but I did find [this page](https://developer.apple.com/library/archive/documentation/Audio/Conceptual/AudioSessionProgrammingGuide/OptimizingForDeviceHardware/OptimizingForDeviceHardware.html#//apple_ref/doc/uid/TP40007875-CH6-SW9) that has not been updated any time recent that suggests `0.02` or 882 samples is a decent value. When I tried that, mic input just stopped working. I suspect if the buffer is too small and being read from too often that it's overwhelming the app and not able to process anything else.

I also played around with removing the `setPreferredIOBufferDuration` completely and then audio just stops working.

Lastly, I think I noticed an issue where if you speak briefly, it's often not transmitted because the speech duration being shorter than the update to enable voice transmission causes no voice to get transmitted. The logic around delaying dispatching `isVoice` was assuming that the sampling length is always 20 milliseconds, but we're setting the buffer here to 63ms, so that seemed incorrect. It's more accurate to derive how long the sampling was by dividing the number of samples over the sampling rate IIUC.