### PR TITLE
allow setting preferred buffer size

### DIFF
--- a/android/src/main/java/com/guilded/gg/AudioInputController.java
+++ b/android/src/main/java/com/guilded/gg/AudioInputController.java
@@ -75,7 +75,7 @@ public class AudioInputController {
         this.listener = listener;
     }
 
-    public void prepareWithSampleRate(int desiredSampleRate) {
+    public void prepareWithSampleRate(int desiredSampleRate, int preferredBufferSize) {
         int sampleRate = 44100; // default sample rate: supported on most android devices
 
         if (desiredSampleRate > 0) {
@@ -84,9 +84,15 @@ public class AudioInputController {
 
         this.sampleRate = sampleRate;
 
-
-        bufferSize = AudioRecord.getMinBufferSize(sampleRate,
-                AudioChannelConfig, AudioSampleFormat);
+        if (preferredBufferSize > 0) {
+            bufferSize = preferredBufferSize;
+        } else {
+            bufferSize = AudioRecord.getMinBufferSize(
+                sampleRate,
+                AudioChannelConfig,
+                AudioSampleFormat
+            );
+        }
     }
 
 

--- a/android/src/main/java/com/guilded/gg/AudioInputController.java
+++ b/android/src/main/java/com/guilded/gg/AudioInputController.java
@@ -44,6 +44,10 @@ public class AudioInputController {
         return this.sampleRate;
     }
 
+    public int bufferSize() {
+        return this.bufferSize;
+    }
+
     public void start() {
         recorder = new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRate,
                 AudioInputController.AudioChannelConfig, AudioInputController.AudioSampleFormat, bufferSize);

--- a/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
+++ b/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
@@ -51,7 +51,19 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
     @ReactMethod
     public void start(ReadableMap options) {
         Log.d(getName(), "Starting");
-        int mode = options != null && options.hasKey("mode") ? options.getInt("mode") : 0;
+
+        int mode = 0;
+        int preferredBufferSize = -1;
+
+        if (options != null) {
+            if (options.hasKey("mode")) {
+                mode = options.getInt("mode");
+            }
+
+            if (options.hasKey("preferredBufferSize")) {
+                preferredBufferSize = options.getInt("preferredBufferSize");
+            }
+        }
 
         RNWebrtcVadModule.initializeVad(mode);
         final AudioInputController inputController = AudioInputController.getInstance();
@@ -59,7 +71,7 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
         // If not specified, will match HW sample, which could be too high.
         // Ex: Most devices run at 48000,41000 (or 48kHz/44.1hHz). So cap at highest vad supported sample rate supported
         // See: https://github.com/TeamGuilded/react-native-webrtc-vad/blob/master/webrtc/common_audio/vad/include/webrtc_vad.h#L75
-        inputController.prepareWithSampleRate(32000);
+        inputController.prepareWithSampleRate(32000, preferredBufferSize);
 
         if (!this.disableInputController) {
             inputController.setAudioInputControllerListener(this);
@@ -88,8 +100,8 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
             final AudioInputController inputController = AudioInputController.getInstance();
             WritableMap settings = Arguments.createMap();
 
-            details.putDouble("hwSampleRate", inputController.sampleRate());
-            details.putDouble("bufferSize", inputController.bufferSize());
+            settings.putDouble("hwSampleRate", inputController.sampleRate());
+            settings.putDouble("bufferSize", inputController.bufferSize());
 
             promise.resolve(settings);
         }

--- a/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
+++ b/android/src/main/java/com/guilded/gg/RNWebrtcVadModule.java
@@ -4,6 +4,7 @@ package com.guilded.gg;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -79,6 +80,23 @@ public class RNWebrtcVadModule extends ReactContextBaseJavaModule implements Aud
         inputController.stop();
         inputController.setAudioInputControllerListener(null);
         audioData = null;
+    }
+
+    @ReactMethod
+    public void audioDeviceSettings(Promise promise) {
+        try {
+            final AudioInputController inputController = AudioInputController.getInstance();
+            WritableMap settings = Arguments.createMap();
+
+            details.putDouble("hwSampleRate", inputController.sampleRate());
+            details.putDouble("bufferSize", inputController.bufferSize());
+
+            promise.resolve(settings);
+        }
+        catch(Exception error) {
+            Log.d(getName(), "reporting audio device settings failed: " + error);
+            promise.reject(error);
+        }
     }
 
     public void setDisableAudioInputController(boolean disableAudioInputController){

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ export default class index {
     RNWebrtcVad.stop();
   }
 
+  static async audioDeviceSettings() {
+    const stats = await RNWebrtcVad.audioDeviceSettings();
+    return stats;
+  }
+
  static addEventListener(type, handler) {
     const listener = RNWebrtcVadEmitter.addListener(EventTypeToNativeEventName[type], handler);
     EventHandlerListeners.set(handler, listener);

--- a/ios/AudioInputController.h
+++ b/ios/AudioInputController.h
@@ -8,6 +8,7 @@
 @interface AudioInputController : NSObject
 @property (nonatomic) id<AudioInputControllerDelegate> delegate;
 @property double audioSampleRate;
+@property double preferredBufferSize;
 @property (nonatomic) dispatch_queue_t audioDataQueue;
 
 + (instancetype) sharedInstance;

--- a/ios/AudioInputController.h
+++ b/ios/AudioInputController.h
@@ -8,13 +8,12 @@
 @interface AudioInputController : NSObject
 @property (nonatomic) id<AudioInputControllerDelegate> delegate;
 @property double audioSampleRate;
-@property double preferredBufferSize;
 @property (nonatomic) dispatch_queue_t audioDataQueue;
 
 + (instancetype) sharedInstance;
 
 - (OSStatus) _initializeAudioGraph;
-- (OSStatus) prepareWithSampleRate:(double)desiredSampleRate;
+- (OSStatus) prepareWithSampleRate:(double)desiredSampleRate preferredBufferSize:(int)preferredBufferSize;
 - (OSStatus) start;
 - (OSStatus) stop;
 @end

--- a/ios/AudioInputController.m
+++ b/ios/AudioInputController.m
@@ -42,7 +42,7 @@
     return res;
 }
 
-- (OSStatus) prepareWithSampleRate:(double)desiredSampleRate {
+- (OSStatus) prepareWithSampleRate:(double)desiredSampleRate preferredBufferSize:(int)preferredBufferSize {
     NSLog(@"[WebRTCVad] sampleRate = %f", desiredSampleRate);
 
     AVAudioSession *audioSession = [AVAudioSession sharedInstance];
@@ -113,8 +113,7 @@
         // Since the OS is not giving us exactly 2048, we'll add a few more on
         // as a buffer, so 2148, which should give us a number that rounds to
         // the OS's buffer durations. The mappings above may change over time.
-        float bufferDuration = 2148 / sampleRate;
-        self.preferredBufferSize = 2148;
+        float bufferDuration = (preferredBufferSize > 0 ? preferredBufferSize : 2148) / sampleRate;
 
         NSLog(@"[WebRTCVad] requesting a buffer duration of %f", bufferDuration);
 

--- a/ios/AudioInputController.m
+++ b/ios/AudioInputController.m
@@ -114,6 +114,7 @@
         // as a buffer, so 2148, which should give us a number that rounds to
         // the OS's buffer durations. The mappings above may change over time.
         float bufferDuration = 2148 / sampleRate;
+        self.preferredBufferSize = 2148;
 
         NSLog(@"[WebRTCVad] requesting a buffer duration of %f", bufferDuration);
 

--- a/ios/RNWebrtcVad.h
+++ b/ios/RNWebrtcVad.h
@@ -5,6 +5,7 @@
 #import <React/RCTEventEmitter.h>
 #endif
 
+#import <AVFoundation/AVFoundation.h>
 #import <Foundation/Foundation.h>
 #import "AudioInputController.h"
 

--- a/ios/RNWebrtcVad.m
+++ b/ios/RNWebrtcVad.m
@@ -16,13 +16,19 @@ RCT_EXPORT_METHOD(start:(NSDictionary *)options)
 {
     NSLog(@"[WebRTCVad] starting = %@", options);
     int mode = [options[@"mode"] intValue];
+    int preferredBufferSize = -1;
+
+    if ([options[@"preferredBufferSize"] intValue] > 0) {
+        preferredBufferSize = [options[@"preferredBufferSize"] intValue];
+    }
+
     voiceDetector = [[VoiceActivityDetector alloc] initWithMode:mode];
     AudioInputController *inputController = [AudioInputController sharedInstance];
 
     // If not specified, will match HW sample, which could be too high.
     // Ex: Most devices run at 48000,41000 (or 48kHz/44.1hHz). So cap at highest vad supported sample rate supported
     // See: https://github.com/TeamGuilded/react-native-webrtc-vad/blob/master/webrtc/common_audio/vad/include/webrtc_vad.h#L75
-    [inputController prepareWithSampleRate:32000];
+    [inputController prepareWithSampleRate:32000 preferredBufferSize:preferredBufferSize];
 
     [inputController start];
 }
@@ -44,7 +50,7 @@ RCT_EXPORT_METHOD(audioDeviceSettings:(RCTPromiseResolveBlock)resolve :(RCTPromi
             @"hwSampleRate" : @(audioSession.sampleRate)
         };
 
-        resolve(details);
+        resolve(settings);
     } @catch (NSException *e) {
         NSLog(@"[WebRTCVad]: reporting audio device settings failed: %@", e.reason);
         reject(@"NSException", @"[WebRTCVad] reporting device settings failed", nil);

--- a/ios/RNWebrtcVad.m
+++ b/ios/RNWebrtcVad.m
@@ -35,6 +35,22 @@ RCT_EXPORT_METHOD(stop) {
     self.audioData = nil;
 }
 
+RCT_EXPORT_METHOD(audioDeviceSettings:(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject) {
+    @try {
+        AVAudioSession *audioSession = [AVAudioSession sharedInstance];
+
+        NSDictionary *settings = @{
+            @"bufferSize" : @(audioSession.IOBufferDuration * audioSession.sampleRate),
+            @"hwSampleRate" : @(audioSession.sampleRate)
+        };
+
+        resolve(details);
+    } @catch (NSException *e) {
+        NSLog(@"[WebRTCVad]: reporting audio device settings failed: %@", e.reason);
+        reject(@"NSException", @"[WebRTCVad] reporting device settings failed", nil);
+    }
+}
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webrtc-vad",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
You should read this PR as two separate commits. The [first](2048c3ad94e1d1e7693f11c92fb40f5c5ed2c41a) adds a function that we can call from the JS side to get details about the sample rate and buffer size used. The [second](61f63575d3fc41781ec74284298c5163e587de12) adds an option to set a preferredBufferSize. Also, there is a change coming to the Guilded side that I will create a PR for in that repo when this is approved.

We'll change the Guilded client to log whenever the call ends, but I imagine that we will not be setting `preferredBufferSize` often, or maybe not at all. This is just a configurable option from the JS side in case we need to (relatively) quickly get a fix out without having to wait for Apple/Google to approve an update.

This is how logging will look like, I imagine:

<img width="830" alt="Screenshot 2023-10-16 at 23 55 19" src="https://github.com/TeamGuilded/react-native-webrtc-vad/assets/1908116/14ae28ed-6898-42e2-949b-c8b2c82e5a81">

And when we set a preferredBufferSize:

<img width="845" alt="Screenshot 2023-10-16 at 23 35 16" src="https://github.com/TeamGuilded/react-native-webrtc-vad/assets/1908116/a826e223-9a03-471a-b573-b247db052d8a">

Note that the above screenshots are for iOS and that when we set a high buffer size, iOS ignores us and does a multiple of 1024 (4096).

This is what it looks like on Android when not specifying and specifying a buffer size:

<img width="835" alt="Screenshot 2023-10-16 at 23 53 53" src="https://github.com/TeamGuilded/react-native-webrtc-vad/assets/1908116/23ef9277-e80d-416e-b1f8-698888475854">

<img width="833" alt="Screenshot 2023-10-16 at 23 49 19" src="https://github.com/TeamGuilded/react-native-webrtc-vad/assets/1908116/78036630-4fa0-4bd3-be47-8f1339b8289a">

Android takes whatever we give it and applies it. If we don't give it, we have some logic to take the smallest buffer size we can. On iOS, we request a hardcoded a value that we tested to actually give us that value. All this means is that if an issue comes up, we should selectively pass in values depending on the OS.